### PR TITLE
fix: close final CodeQL stack-trace alert

### DIFF
--- a/src/api/v1/main.py
+++ b/src/api/v1/main.py
@@ -9,7 +9,6 @@ import uuid
 from datetime import datetime
 from typing import (  # noqa: F401 (kept for future extensibility)
     Any,
-    Dict,
     NoReturn,
     Optional,
     cast,
@@ -69,6 +68,9 @@ logger = logging.getLogger(__name__)
 METRICS_MAX_SAMPLES = 500
 METRICS_ACTIVE_REQUEST_TTL_S = 3600
 METRICS_PREFIX = "doctoralia:api:metrics"
+SCHEDULE_RUN_FAILURE_MESSAGE = "Schedule execution failed"
+SCHEDULE_RUN_SUCCESS_MESSAGE = "Schedule executed successfully"
+SCHEDULE_RUN_HEALTH_CHECK_ERROR = "Health check failed"
 _metrics_store_cache: Optional[RedisAPIMetricsStore] = None
 _metrics_store_cache_url: Optional[str] = None
 _telegram_schedule_service: Optional[TelegramScheduleService] = None
@@ -165,32 +167,65 @@ def _http_error_code(status_code: int) -> str:
     }.get(status_code, f"HTTP_{status_code}")
 
 
-def _sanitize_schedule_run_response(raw_response: Dict[str, Any]) -> Dict[str, Any]:
+def _sanitize_schedule_run_metrics(raw_metrics: Any) -> dict[str, Any]:
+    if not isinstance(raw_metrics, dict):
+        return {}
+
+    safe_metrics: dict[str, Any] = {}
+    for field in (
+        "total_reviews",
+        "generated_responses",
+        "scraped",
+        "profile_url",
+        "manual",
+    ):
+        if field in raw_metrics:
+            safe_metrics[field] = raw_metrics[field]
+
+    health_checks = raw_metrics.get("health_checks")
+    if isinstance(health_checks, dict):
+        safe_health_checks: dict[str, Any] = {}
+        for component, component_data in health_checks.items():
+            if not isinstance(component_data, dict):
+                safe_health_checks[component] = component_data
+                continue
+
+            safe_component = {
+                key: value for key, value in component_data.items() if key != "error"
+            }
+            if component_data.get("error"):
+                safe_component["error"] = SCHEDULE_RUN_HEALTH_CHECK_ERROR
+            safe_health_checks[component] = safe_component
+
+        safe_metrics["health_checks"] = safe_health_checks
+
+    return safe_metrics
+
+
+def _sanitize_schedule_run_response(raw_response: dict[str, Any]) -> dict[str, Any]:
     raw_result = raw_response.get("result")
-    safe_result: Dict[str, Any] = {}
+    safe_result: dict[str, Any] = {}
 
     if isinstance(raw_result, dict):
-        for field in (
-            "sent",
-            "schedule_id",
-            "schedule_name",
-            "metrics",
-            "doctor_name",
-            "attachment_path",
-        ):
+        if raw_result.get("error"):
+            safe_result["error"] = SCHEDULE_RUN_FAILURE_MESSAGE
+
+        for field in ("sent", "schedule_id", "schedule_name", "doctor_name"):
             if field in raw_result:
                 safe_result[field] = raw_result[field]
 
-        if raw_result.get("error"):
-            safe_result["error"] = "Schedule execution failed"
+        if "metrics" in raw_result:
+            safe_result["metrics"] = _sanitize_schedule_run_metrics(
+                raw_result["metrics"]
+            )
 
     success = bool(raw_response.get("success"))
     return {
         "success": success,
         "message": (
-            str(raw_response.get("message") or "Schedule executed successfully")
+            str(raw_response.get("message") or SCHEDULE_RUN_SUCCESS_MESSAGE)
             if success
-            else "Schedule execution failed"
+            else SCHEDULE_RUN_FAILURE_MESSAGE
         ),
         "result": safe_result,
     }

--- a/src/api/v1/main.py
+++ b/src/api/v1/main.py
@@ -9,6 +9,7 @@ import uuid
 from datetime import datetime
 from typing import (  # noqa: F401 (kept for future extensibility)
     Any,
+    Dict,
     NoReturn,
     Optional,
     cast,
@@ -162,6 +163,37 @@ def _http_error_code(status_code: int) -> str:
         status.HTTP_404_NOT_FOUND: "NOT_FOUND",
         status.HTTP_500_INTERNAL_SERVER_ERROR: "INTERNAL_ERROR",
     }.get(status_code, f"HTTP_{status_code}")
+
+
+def _sanitize_schedule_run_response(raw_response: Dict[str, Any]) -> Dict[str, Any]:
+    raw_result = raw_response.get("result")
+    safe_result: Dict[str, Any] = {}
+
+    if isinstance(raw_result, dict):
+        for field in (
+            "sent",
+            "schedule_id",
+            "schedule_name",
+            "metrics",
+            "doctor_name",
+            "attachment_path",
+        ):
+            if field in raw_result:
+                safe_result[field] = raw_result[field]
+
+        if raw_result.get("error"):
+            safe_result["error"] = "Schedule execution failed"
+
+    success = bool(raw_response.get("success"))
+    return {
+        "success": success,
+        "message": (
+            str(raw_response.get("message") or "Schedule executed successfully")
+            if success
+            else "Schedule execution failed"
+        ),
+        "result": safe_result,
+    }
 
 
 def _get_metrics_store() -> Optional[RedisAPIMetricsStore]:
@@ -1050,7 +1082,7 @@ async def run_telegram_notification_schedule(schedule_id: str):
     try:
         service = _get_telegram_schedule_service(start_runner=True)
         result = service.execute_schedule(schedule_id, manual=True)
-        return result
+        return _sanitize_schedule_run_response(result)
     except ValueError as exc:
         _raise_public_http_error(
             status.HTTP_404_NOT_FOUND,

--- a/tests/n8n/test_api.py
+++ b/tests/n8n/test_api.py
@@ -348,6 +348,16 @@ class TestTelegramNotificationEndpoints:
                 "error": "Traceback: Redis timeout at /tmp/internal/path",
                 "schedule_id": "schedule-1",
                 "schedule_name": "Matinal",
+                "attachment_path": "/tmp/internal/path/report.txt",
+                "metrics": {
+                    "manual": True,
+                    "health_checks": {
+                        "redis": {
+                            "status": "failed",
+                            "error": "ConnectionError: redis://internal-host:6379",
+                        }
+                    },
+                },
             },
         }
         mock_get_service.return_value = service
@@ -364,8 +374,138 @@ class TestTelegramNotificationEndpoints:
         assert response_body["result"]["error"] == "Schedule execution failed"
         assert "Traceback: Redis timeout" not in str(response_body)
         assert "/tmp/internal/path" not in str(response_body)
+        assert "internal-host" not in str(response_body)
         assert response_body["result"]["schedule_id"] == "schedule-1"
         assert response_body["result"]["schedule_name"] == "Matinal"
+        assert "attachment_path" not in response_body["result"]
+        assert response_body["result"]["metrics"]["manual"] is True
+        assert (
+            response_body["result"]["metrics"]["health_checks"]["redis"]["error"]
+            == "Health check failed"
+        )
+
+    @patch("src.api.v1.main._get_telegram_schedule_service")
+    def test_run_telegram_notification_schedule_sanitizes_success_result_with_default_message(
+        self, mock_get_service, client, mock_env, api_key
+    ):
+        service = MagicMock()
+        service.execute_schedule.return_value = {
+            "success": True,
+            "result": {
+                "sent": True,
+                "schedule_id": "schedule-1",
+                "schedule_name": "Matinal",
+                "doctor_name": "Dra. Ana",
+                "attachment_path": "/tmp/should/not/leak.txt",
+                "internal_debug": "should be dropped",
+                "metrics": {
+                    "manual": True,
+                    "health_checks": {
+                        "api": {
+                            "status": "ok",
+                            "latency_ms": 14,
+                        }
+                    },
+                },
+            },
+        }
+        mock_get_service.return_value = service
+
+        response = client.post(
+            "/v1/notifications/telegram/schedules/schedule-1/run",
+            headers={"X-API-Key": api_key},
+        )
+
+        assert response.status_code == 200
+        response_body = response.json()
+        assert response_body["success"] is True
+        assert response_body["message"] == "Schedule executed successfully"
+        assert response_body["result"] == {
+            "sent": True,
+            "schedule_id": "schedule-1",
+            "schedule_name": "Matinal",
+            "doctor_name": "Dra. Ana",
+            "metrics": {
+                "manual": True,
+                "health_checks": {
+                    "api": {
+                        "status": "ok",
+                        "latency_ms": 14,
+                    }
+                },
+            },
+        }
+
+    @patch("src.api.v1.main._get_telegram_schedule_service")
+    def test_run_telegram_notification_schedule_sanitizes_success_result_with_custom_message(
+        self, mock_get_service, client, mock_env, api_key
+    ):
+        service = MagicMock()
+        service.execute_schedule.return_value = {
+            "success": True,
+            "message": "Custom success message",
+            "result": {
+                "sent": True,
+                "schedule_id": "schedule-1",
+                "schedule_name": "Matinal",
+                "extra_field": "should be dropped",
+            },
+        }
+        mock_get_service.return_value = service
+
+        response = client.post(
+            "/v1/notifications/telegram/schedules/schedule-1/run",
+            headers={"X-API-Key": api_key},
+        )
+
+        assert response.status_code == 200
+        response_body = response.json()
+        assert response_body["success"] is True
+        assert response_body["message"] == "Custom success message"
+        assert response_body["result"] == {
+            "sent": True,
+            "schedule_id": "schedule-1",
+            "schedule_name": "Matinal",
+        }
+
+    @patch("src.api.v1.main._get_telegram_schedule_service")
+    def test_run_telegram_notification_schedule_handles_unexpected_result_shapes(
+        self, mock_get_service, client, mock_env, api_key
+    ):
+        service = MagicMock()
+        service.execute_schedule.return_value = {
+            "success": True,
+            "message": "Ok but with missing result",
+        }
+        mock_get_service.return_value = service
+
+        response = client.post(
+            "/v1/notifications/telegram/schedules/schedule-1/run",
+            headers={"X-API-Key": api_key},
+        )
+
+        assert response.status_code == 200
+        response_body = response.json()
+        assert response_body["success"] is True
+        assert response_body["message"] == "Ok but with missing result"
+        assert response_body["result"] == {}
+
+        service.execute_schedule.return_value = {
+            "success": True,
+            "message": "Ok but result is a list",
+            "result": ["should", "not", "leak"],
+        }
+
+        response = client.post(
+            "/v1/notifications/telegram/schedules/schedule-1/run",
+            headers={"X-API-Key": api_key},
+        )
+
+        assert response.status_code == 200
+        response_body = response.json()
+        assert response_body["success"] is True
+        assert response_body["message"] == "Ok but result is a list"
+        assert response_body["result"] == {}
 
     @patch("src.api.v1.main._get_telegram_schedule_service")
     def test_list_telegram_notification_history(

--- a/tests/n8n/test_api.py
+++ b/tests/n8n/test_api.py
@@ -336,6 +336,38 @@ class TestTelegramNotificationEndpoints:
         assert "detail" not in response_body["error"]
 
     @patch("src.api.v1.main._get_telegram_schedule_service")
+    def test_run_telegram_notification_schedule_sanitizes_failed_result(
+        self, mock_get_service, client, mock_env, api_key
+    ):
+        service = MagicMock()
+        service.execute_schedule.return_value = {
+            "success": False,
+            "message": "Falha interna no schedule Matinal",
+            "result": {
+                "sent": False,
+                "error": "Traceback: Redis timeout at /tmp/internal/path",
+                "schedule_id": "schedule-1",
+                "schedule_name": "Matinal",
+            },
+        }
+        mock_get_service.return_value = service
+
+        response = client.post(
+            "/v1/notifications/telegram/schedules/schedule-1/run",
+            headers={"X-API-Key": api_key},
+        )
+
+        assert response.status_code == 200
+        response_body = response.json()
+        assert response_body["success"] is False
+        assert response_body["message"] == "Schedule execution failed"
+        assert response_body["result"]["error"] == "Schedule execution failed"
+        assert "Traceback: Redis timeout" not in str(response_body)
+        assert "/tmp/internal/path" not in str(response_body)
+        assert response_body["result"]["schedule_id"] == "schedule-1"
+        assert response_body["result"]["schedule_name"] == "Matinal"
+
+    @patch("src.api.v1.main._get_telegram_schedule_service")
     def test_list_telegram_notification_history(
         self, mock_get_service, client, mock_env, api_key
     ):


### PR DESCRIPTION
## Summary
- sanitize the manual telegram schedule run response before returning it from the API
- replace any internal execution error text with a generic public-safe message
- add regression coverage to ensure traceback/path details are not exposed

## Validation
- poetry run pytest tests/n8n/test_api.py
- poetry run black --check src/api/v1/main.py tests/n8n/test_api.py
- poetry run flake8 src/api/v1/main.py tests/n8n/test_api.py --extend-ignore=E203 --max-line-length=120

## Summary by Sourcery

Sanitize the Telegram schedule run API response to avoid exposing internal error details and ensure consistent, user-safe output.

Bug Fixes:
- Prevent internal traceback and path details from being exposed in the Telegram schedule manual run API response.

Enhancements:
- Normalize the Telegram schedule run API response fields and error messages into a public-safe format.

Tests:
- Add regression test to verify that failed Telegram schedule runs return sanitized error information without leaking internal details.