### PR TITLE
fix: correct static assets path in Dockerfile and dashboard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
 
 COPY src ./src
 COPY templates ./templates
-COPY static ./static
 
 # Create necessary directories
 RUN mkdir -p data/logs data/responses data/temp logs

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -48,7 +48,7 @@ class DashboardApp:
         self.app = Flask(
             __name__,
             template_folder=str(Path(__file__).parent.parent.parent / "templates"),
-            static_folder=str(Path(__file__).parent.parent.parent / "static"),
+            static_folder=str(Path(__file__).parent.parent / "static"),
         )
         CORS(self.app)
 


### PR DESCRIPTION
## Problema

Docker Build & Push falhava com `"/static": not found` — Dockerfile fazia `COPY static ./static` mas **não existe** `static/` na raiz. Assets ficam em `src/static/`.

Bug espelhado no dashboard: `static_folder` apontava p/ `parent.parent.parent / "static"` (raiz), que nunca existiu → static inacessível também local.

## Fix

- **Dockerfile**: removido `COPY static ./static` quebrado. Assets já vêm via `COPY src ./src` → `/app/src/static`.
- **app.py**: `static_folder` → `parent.parent / "static"` (= `src/static`), onde os assets realmente estão.

## Validação local

```
static_folder resolve → src/static (10 files) ✓
black ✓  flake8 ✓  mypy ✓  import OK
pytest: 359 passed, 7 skipped
```

Corrige o último check vermelho (Docker). CI já 100% verde no merge anterior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)