### PR TITLE
fix(runtime): auto-init PostgreSQL and honor runtime integration env vars

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -260,6 +260,9 @@ jobs:
             api:
               image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/api:${{ env.IMAGE_TAG }}
               build: null
+            db-init:
+              image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/api:${{ env.IMAGE_TAG }}
+              build: null
             worker:
               image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/worker:${{ env.IMAGE_TAG }}
               build: null

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ make lint
 | `POST`                | `/v1/scrape:run`                                         | Scraping síncrono                      |
 | `POST`                | `/v1/jobs`                                               | Cria job assíncrono                    |
 | `GET`                 | `/v1/jobs/{job_id}`                                      | Consulta job                           |
-| `GET`                 | `/v1/ready`                                              | Readiness com Redis, Selenium e NLTK   |
+| `GET`                 | `/v1/ready`                                              | Readiness com Redis, fila, PostgreSQL, Selenium e NLTK |
 | `GET`                 | `/v1/metrics`                                            | Métricas da API persistidas em Redis   |
 | `GET`                 | `/v1/auth/status`                                        | Estado da autenticação do dashboard    |
 | `POST`                | `/v1/auth/login`                                         | Validação de credenciais do dashboard  |
@@ -124,9 +124,9 @@ make lint
 
 | Tema              | Situação                                                                |
 | ----------------- | ----------------------------------------------------------------------- |
-| Stack Docker      | `api`, `worker`, `dashboard`, `redis`, `selenium`, `n8n`                |
+| Stack Docker      | `api`, `worker`, `dashboard`, `db`/`db-init`, `redis`, `selenium`, `n8n` |
 | Workspace web     | Operacional, autenticado e com scheduler Telegram integrado             |
-| Persistência      | Snapshots em `data/` e histórico/schedules em Redis                     |
+| Persistência      | Snapshots em `data/`, histórico/schedules em Redis e schema base em PostgreSQL |
 | Métricas da API   | Redis-backed, multi-processo                                            |
 | n8n local         | preso em `127.0.0.1:5678`, com auth e encryption key obrigatórias       |
 | Testes            | suíte cobrindo áreas críticas de API, dashboard, jobs, Redis e Telegram |

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -62,6 +62,11 @@ services:
       db:
         condition: service_healthy
 
+  db-init:
+    restart: "no"
+    environment:
+      - DATABASE_URL=postgresql+asyncpg://${POSTGRES_USER:-doctoralia}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@db:5432/${POSTGRES_DB:-doctoralia}
+
   n8n:
     ports: !reset []
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
         condition: service_healthy
       db:
         condition: service_healthy
+      db-init:
+        condition: service_completed_successfully
     ports:
       - "8000:8000"
     volumes:
@@ -70,6 +72,8 @@ services:
         condition: service_healthy
       db:
         condition: service_healthy
+      db-init:
+        condition: service_completed_successfully
       # selenium is NOT required for the worker process to start; it is used
       # only when a scraping task is actually executed.
     volumes:
@@ -145,6 +149,20 @@ services:
         reservations:
           cpus: "0.25"
           memory: 128M
+
+  db-init:
+    build:
+      context: .
+      target: api
+    command: ["python", "-m", "src.db.init_db", "init-and-seed"]
+    environment:
+      - DATABASE_URL=postgresql+asyncpg://${POSTGRES_USER:-doctoralia}:${POSTGRES_PASSWORD:-doctoralia}@db:5432/${POSTGRES_DB:-doctoralia}
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - doctoralia-net
+    restart: "no"
 
   selenium:
     image: selenium/standalone-chrome:latest
@@ -226,6 +244,8 @@ services:
         condition: service_healthy
       db:
         condition: service_healthy
+      db-init:
+        condition: service_completed_successfully
     ports:
       - "5000:5000"
     volumes:

--- a/docs/api.md
+++ b/docs/api.md
@@ -409,7 +409,8 @@ Verifica disponibilidade de todas as dependências.
     "queue": true,
     "templates": true,
     "nltk_vader": true,
-    "selenium": true
+    "selenium": true,
+    "database": true
   },
   "components": {
     "redis": {
@@ -425,6 +426,11 @@ Verifica disponibilidade de todas as dependências.
         "depth": 3,
         "failed": 0
       }
+    },
+    "database": {
+      "status": true,
+      "latency_ms": 8,
+      "error": null
     },
     ...
   }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -97,13 +97,16 @@ adiciona **Caddy** como reverse proxy com **TLS automático** na frente de
 `api`, `dashboard` e `n8n`. O overlay também:
 
 - remove a publicação direta das portas internas (só o Caddy expõe 80/443);
-- exige senha no Redis (`REDIS_PASSWORD`) e injeta a URL autenticada na API/worker;
+- exige senha no Redis (`REDIS_PASSWORD`) e no Postgres (`POSTGRES_PASSWORD`),
+  injetando URLs autenticadas na API/worker/dashboard;
+- executa `db-init` antes dos serviços dependentes para criar/semear o schema
+  base do PostgreSQL de forma idempotente;
 - aplica `restart: always` em todos os serviços.
 
 ### Subir em produção
 
 ```bash
-# Defina no .env: APP_DOMAIN, N8N_DOMAIN, REDIS_PASSWORD
+# Defina no .env: APP_DOMAIN, N8N_DOMAIN, REDIS_PASSWORD, POSTGRES_PASSWORD
 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
 docker compose -f docker-compose.yml -f docker-compose.prod.yml ps
 ```
@@ -126,6 +129,7 @@ Variáveis relevantes no `.env`:
 APP_DOMAIN=app.seudominio.com      # dashboard + API
 N8N_DOMAIN=n8n.seudominio.com      # editor n8n
 REDIS_PASSWORD=<openssl rand -hex 24>
+POSTGRES_PASSWORD=<openssl rand -hex 24>
 # Opcional: se a porta 443 do host já estiver em uso (teste local)
 CADDY_HTTP_PORT=8080
 CADDY_HTTPS_PORT=8443
@@ -147,7 +151,7 @@ respostas, redireciona HTTP→HTTPS automaticamente e roteia:
 
 ```bash
 curl -H "X-API-Key: $API_KEY" http://localhost:8000/v1/health
-curl http://localhost:8000/v1/ready
+curl http://localhost:8000/v1/ready  # Redis, fila, PostgreSQL, Selenium e NLTK
 curl http://localhost:8000/v1/auth/status
 ```
 
@@ -175,43 +179,17 @@ sudo ufw enable
 
 ## Backup e Recuperação
 
-### Backup Automático
+### Backup / Restore
 
 ```bash
-#!/bin/bash
-BACKUP_DIR="/backup/$(date +%Y%m%d_%H%M%S)"
-mkdir -p $BACKUP_DIR
-
-# Backup Redis
-docker exec redis redis-cli --rdb /data/dump.rdb
-docker cp redis:/data/dump.rdb $BACKUP_DIR/redis.rdb
-
-# Backup dados de scraping
-tar -czf $BACKUP_DIR/data.tgz data/
-
-# Backup n8n workflows
-docker exec n8n n8n export:workflow --all --output=/tmp/workflows.json
-docker cp n8n:/tmp/workflows.json $BACKUP_DIR/
-
-# Backup configs
-cp .env $BACKUP_DIR/
-cp config/config.json $BACKUP_DIR/
-
-# Limpar backups antigos (>30 dias)
-find /backup -type d -mtime +30 -exec rm -rf {} \;
+scripts/backup_restore.sh backup
+scripts/backup_restore.sh verify backups/backup_YYYYmmdd_HHMMSS.tar.gz
+scripts/backup_restore.sh restore backups/backup_YYYYmmdd_HHMMSS.tar.gz
 ```
 
-### Restore
-
-```bash
-# Restore Redis
-docker cp backup/redis.rdb redis:/data/dump.rdb
-docker restart redis
-
-# Restore n8n
-docker cp backup/workflows.json n8n:/tmp/
-docker exec n8n n8n import:workflow --input=/tmp/workflows.json
-```
+O script captura `data/`, `src/config/`, `.env`, dump RDB do Redis, dump SQL
+do PostgreSQL (`pg_dump`) e workflows do n8n quando os containers estão em
+execução. O `restore` valida o arquivo antes de aplicar mudanças.
 
 ### Cron de Backup
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -11,7 +11,7 @@ Esta página concentra o runbook do projeto: health, logs, agendamentos, retenç
 | Endpoint | Uso |
 |---|---|
 | `/v1/health` | disponibilidade básica da API |
-| `/v1/ready` | readiness com Redis, queue, Selenium e NLTK |
+| `/v1/ready` | readiness com Redis, queue, PostgreSQL, Selenium e NLTK |
 | `/v1/statistics` | estatísticas agregadas |
 | `/v1/metrics` | métricas Redis-backed da API |
 

--- a/src/api/v1/routers/health.py
+++ b/src/api/v1/routers/health.py
@@ -6,10 +6,12 @@ from urllib.parse import urlparse
 import requests
 from fastapi import APIRouter, Depends, status
 from fastapi.responses import JSONResponse
+from sqlalchemy import text
 
 from src.api.schemas.common import HealthResponse, ReadyComponent, ReadyResponse
 from src.api.v1._state import API_VERSION
 from src.api.v1.providers import get_app_config, get_job_queue_factory
+from src.db.base import get_sessionmaker
 
 router = APIRouter(tags=["Health"])
 
@@ -132,6 +134,25 @@ async def readiness_check(
         status=selenium_ok,
         latency_ms=selenium_latency,
         error=selenium_error,
+        details=None,
+    )
+
+    database_ok = False
+    database_error = None
+    database_latency = None
+    try:
+        start = time.perf_counter()
+        async_session = get_sessionmaker()
+        async with async_session() as session:
+            await session.execute(text("SELECT 1"))
+        database_latency = int((time.perf_counter() - start) * 1000)
+        database_ok = True
+    except Exception as exc:  # pragma: no cover
+        database_error = str(exc)[:300]
+    components["database"] = ReadyComponent(
+        status=database_ok,
+        latency_ms=database_latency,
+        error=database_error,
         details=None,
     )
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -405,21 +405,27 @@ class AppConfig:
 
                 integrations_data = data.get("integrations", {})
                 integrations = IntegrationConfig(
-                    redis_url=integrations_data.get(
-                        "redis_url", os.getenv("REDIS_URL", integrations.redis_url)
+                    # Runtime integration endpoints may carry deployment-only
+                    # credentials (for example redis://:<password>@redis:6379/0
+                    # from docker-compose.prod.yml). Environment variables must
+                    # override a persisted config.json so mounted local settings
+                    # cannot silently break containerized production wiring.
+                    redis_url=os.getenv(
+                        "REDIS_URL",
+                        integrations_data.get("redis_url", integrations.redis_url),
                     ),
-                    selenium_remote_url=integrations_data.get(
-                        "selenium_remote_url",
-                        os.getenv(
-                            "SELENIUM_REMOTE_URL", integrations.selenium_remote_url
+                    selenium_remote_url=os.getenv(
+                        "SELENIUM_REMOTE_URL",
+                        integrations_data.get(
+                            "selenium_remote_url", integrations.selenium_remote_url
                         ),
                     ),
                     api_url=_clean_optional(
-                        integrations_data.get("api_url") or os.getenv("API_URL")
+                        os.getenv("API_URL") or integrations_data.get("api_url")
                     ),
                     api_public_url=_clean_optional(
-                        integrations_data.get("api_public_url")
-                        or os.getenv("API_PUBLIC_URL")
+                        os.getenv("API_PUBLIC_URL")
+                        or integrations_data.get("api_public_url")
                     ),
                 )
 

--- a/tests/n8n/test_api.py
+++ b/tests/n8n/test_api.py
@@ -168,6 +168,60 @@ class TestHealthEndpoints:
             response = client.get("/v1/ready")
             assert response.status_code == 503
 
+    def test_ready_check_reports_database_failure(self, client):
+        """Readiness should include database diagnostics when Postgres is down."""
+
+        class FailingSession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def execute(self, *_args, **_kwargs):
+                raise RuntimeError("database unavailable")
+
+        class FakeRedis:
+            def ping(self):
+                return True
+
+        fake_queue = SimpleNamespace(
+            count=0,
+            name="doctoralia",
+            connection=object(),
+        )
+        fake_registry = MagicMock()
+        fake_registry.get_job_ids.return_value = []
+        fake_response = MagicMock()
+        fake_response.raise_for_status.return_value = None
+
+        from src.api.v1.providers import get_job_queue_factory
+
+        client.app.dependency_overrides[get_job_queue_factory] = lambda: (
+            lambda: fake_queue
+        )
+        try:
+            with (
+                patch("redis.Redis.from_url", return_value=FakeRedis()),
+                patch("rq.registry.FailedJobRegistry", return_value=fake_registry),
+                patch("requests.get", return_value=fake_response),
+                patch("src.response_quality_analyzer.ResponseQualityAnalyzer"),
+                patch(
+                    "src.api.v1.routers.health.get_sessionmaker",
+                    return_value=lambda: FailingSession(),
+                ),
+            ):
+                response = client.get("/v1/ready")
+        finally:
+            client.app.dependency_overrides.pop(get_job_queue_factory, None)
+
+        assert response.status_code == 503
+        data = response.json()
+        assert data["checks"]["database"] is False
+        assert "database unavailable" in data["components"]["database"]["error"]
+        assert data["checks"]["redis"] is True
+        assert data["checks"]["queue"] is True
+
     def test_metrics_endpoint_uses_redis_backed_store(self, client):
         """Metrics endpoint should expose Redis-backed counters and middleware timings."""
         metrics_store = MagicMock()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -287,13 +287,18 @@ class TestAppConfig:
         assert loaded.telegram.enabled is True
         assert loaded.telegram.parse_mode == "HTML"
         assert loaded.security.api_key == "file-api-key-123"
-        assert loaded.security.openai_api_key == "sk-file-openai-key"
+        assert loaded.security.openai_api_key == source_config.security.openai_api_key
         assert loaded.generation.mode == "openai"
         assert loaded.generation.gemini_api_key == "gemini-secret"
-        assert loaded.integrations.redis_url == "redis://redis.internal:6379/1"
+        # Runtime integration endpoints come from the environment when set so
+        # container deployment wiring (including credentials in REDIS_URL) wins
+        # over stale persisted UI settings.
+        assert loaded.integrations.redis_url == "redis://env-redis:6379/0"
         assert (
-            loaded.integrations.api_public_url == "https://doctoralia.example.com/api"
+            loaded.integrations.selenium_remote_url == "http://env-selenium:4444/wd/hub"
         )
+        assert loaded.integrations.api_url == "http://env-api:8000"
+        assert loaded.integrations.api_public_url == "https://env.example.com/api"
         assert loaded.privacy.mask_pii is False
         assert loaded.privacy.allowed_callback_domains == [
             "hooks.example.com",


### PR DESCRIPTION
## Resumo

Corrige os problemas encontrados ao validar a versão recém-mergeada rodando de fato na máquina local com `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build`.

A stack anterior parecia saudável pelo `/v1/health`, mas o runtime real mostrava duas falhas:

1. `/v1/ready` retornava 503 porque `AppConfig.load()` priorizava `src/config/config.json` sobre variáveis de ambiente para integrações runtime. Na prática, o container recebia `REDIS_URL=redis://:<senha>@redis:6379/0`, mas a API usava o `redis_url` persistido no config montado (`redis://redis:6379/0`), quebrando Redis autenticado em produção.
2. O serviço `db` subia saudável, mas o schema PostgreSQL ficava vazio até alguém rodar manualmente `python -m src.db.init_db init-and-seed`.

## Mudanças

- `src/config/settings.py`
  - `REDIS_URL`, `SELENIUM_REMOTE_URL`, `API_URL` e `API_PUBLIC_URL` agora vêm do ambiente quando definidos.
  - Isso preserva config persistida de UI/usuário, mas impede que `config.json` stale sobrescreva credenciais/endpoints injetados por Compose/produção.

- `docker-compose.yml`
  - Adiciona serviço one-shot `db-init` que roda `python -m src.db.init_db init-and-seed`.
  - `api`, `worker` e `dashboard` passam a depender de `db-init: service_completed_successfully`.
  - Resultado: stack nova cria/semeia o schema antes dos serviços dependentes subirem.

- `docker-compose.prod.yml`
  - `db-init` usa a mesma `DATABASE_URL` com `POSTGRES_PASSWORD` obrigatório do overlay de produção.

- `src/api/v1/routers/health.py`
  - `/v1/ready` agora inclui check `database` com `SELECT 1` via SQLAlchemy async.
  - Isso torna falhas de Postgres visíveis no readiness em vez de apenas no runtime.

- `.github/workflows/docker.yml`
  - Em runs não-PR que usam imagens publicadas, `db-init` também aponta para a imagem publicada de API; evita build local inconsistente do target `api` só para init.

- Docs (`README.md`, `docs/api.md`, `docs/deployment.md`, `docs/operations.md`)
  - Atualizadas para mencionar PostgreSQL no readiness, `db-init`, senha obrigatória do Postgres no overlay de produção e o script real de backup/restore.

## Validação local

### Testes/unitários focados

- `poetry run pytest tests/test_config.py::TestAppConfig::test_load_reads_extended_settings_sections tests/n8n/test_api.py::TestHealthEndpoints::test_ready_check_without_redis tests/n8n/test_api.py::TestHealthEndpoints::test_ready_check_reports_database_failure -q`
- Resultado: `3 passed`.

### Suíte completa

- `poetry run pytest tests/ -q -p no:cacheprovider`
- Resultado: suíte completa verde; apenas os 7 skips esperados de Redis real em `localhost:6379` indisponível.

### Gates locais espelhando CI

- `poetry run black --check src/ tests/ scripts/`
- `poetry run isort --check-only src/ tests/ scripts/`
- `poetry run flake8 src/ scripts/ --extend-ignore=E203,W503,E501`
- `poetry run mypy src/ --ignore-missing-imports`
- `poetry run bandit -r src/ -ll -f json -o /tmp/doctoralia-bandit-report.json`
- `poetry run pip-audit --requirement requirements.txt --progress-spinner off`
- `poetry run make deps-check`
- Resultado: todos verdes; `pip-audit`: `No known vulnerabilities found`.

### Compose e runtime real

- `docker compose config --quiet`
- `REDIS_PASSWORD=dummy POSTGRES_PASSWORD=dummy docker compose -f docker-compose.yml -f docker-compose.prod.yml config --quiet`
- Resultado: ambos verdes.

- Stack real recriada com overlay de produção:
  - `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build`

- `db-init` executou com sucesso:
  - `Database schema initialized (tables created if not exist)`
  - `Database seeding completed`

- Postgres real validado:
  - tabelas: `users`, `workspaces`, `memberships`
  - seed: `users=1`, `workspaces=1`, `memberships=1`

- `/v1/ready` interno validado dentro do container API:
  - `ready=True`
  - checks: `redis=True`, `queue=True`, `templates=True`, `nltk_vader=True`, `selenium=True`, `database=True`

- Redis real validado dentro do container API:
  - `REDIS_URL` contém autenticação
  - `ping=True`

- Logs recentes de `api`, `worker`, `dashboard`, `db-init`:
  - sem `ERROR`, `Traceback`, `Exception`, `HELLO must...` ou `Connection refused` no período validado.

## Nota de validação local bloqueada

A validação externa via `curl -k https://localhost:8443/...` foi bloqueada pela camada local de aprovação da ferramenta nesta sessão; não tentei contornar. A validação de runtime foi feita via Compose interno, API containerizada, DB real, Redis real, logs e healthchecks dos containers.
