### PR TITLE
fix(ci): arm auto-merge before updating dependabot branches

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -59,26 +59,14 @@ jobs:
 
             const pr = await waitForStablePullRequest(initialPr.number);
 
-            if (pr.mergeable_state === "behind") {
-              try {
-                await github.rest.pulls.updateBranch({
-                  owner,
-                  repo,
-                  pull_number: pr.number,
-                  expected_head_sha: pr.head.sha,
-                });
-                core.info(`Updated branch for PR #${pr.number}. Waiting for the synchronize event to retry auto-merge.`);
-              } catch (error) {
-                core.warning(`Could not update branch for PR #${pr.number}: ${error.message}`);
-              }
-              return;
-            }
-
             if (pr.mergeable === null || ["unknown", "unstable"].includes(pr.mergeable_state)) {
               core.warning(`Skipping PR #${pr.number}: mergeable state is still ${pr.mergeable_state}.`);
               return;
             }
 
+            // Enable auto-merge before touching the branch. updateBranch pushes with
+            // GITHUB_TOKEN, which does not fire the synchronize event this workflow
+            // would need to run again, so a "behind" PR must be armed first.
             try {
               await github.graphql(
                 `mutation($pullRequestId: ID!) {
@@ -92,13 +80,37 @@ jobs:
               );
               core.info(`Auto-merge enabled for PR #${pr.number}.`);
             } catch (error) {
-              if ((error.message || "").includes("already enabled")) {
+              const message = error.message || "";
+              if (message.includes("already enabled")) {
                 core.info(`Auto-merge is already enabled for PR #${pr.number}.`);
+              } else if (message.includes("clean status")) {
+                // "clean" means every required check passed and the branch is current.
+                await github.rest.pulls.merge({
+                  owner,
+                  repo,
+                  pull_number: pr.number,
+                  merge_method: "squash",
+                });
+                core.info(`PR #${pr.number} was already mergeable; merged directly.`);
                 return;
-              }
-              if ((error.message || "").includes("unstable status")) {
+              } else if (message.includes("unstable status")) {
                 core.warning(`Skipping PR #${pr.number}: GitHub still reports the pull request as unstable.`);
                 return;
+              } else {
+                throw error;
               }
-              throw error;
+            }
+
+            if (pr.mergeable_state === "behind") {
+              try {
+                await github.rest.pulls.updateBranch({
+                  owner,
+                  repo,
+                  pull_number: pr.number,
+                  expected_head_sha: pr.head.sha,
+                });
+                core.info(`Updated branch for PR #${pr.number}; auto-merge will complete it.`);
+              } catch (error) {
+                core.warning(`Could not update branch for PR #${pr.number}: ${error.message}`);
+              }
             }


### PR DESCRIPTION
## Problema

PR #150 (dependabot, todos os checks verdes, `mergeStateStatus=CLEAN`) ficou aberto desde 27/07 sem nunca ser mesclado, apesar da política de auto-merge universal.

Log do run `30264998726`:

```
Attempt 1/6: mergeable=true mergeable_state=behind
Updated branch for PR #150. Waiting for the synchronize event to retry auto-merge.
```

O script chamava `pulls.updateBranch` e retornava, esperando um evento `synchronize` para rodar de novo. Esse push é feito com `GITHUB_TOKEN`, que não dispara novos runs de `pull_request_target` — a retentativa nunca acontece. Resultado: o PR fica verde e parado para sempre.

## Correção

1. **Ordem invertida**: habilita o auto-merge *antes* de atualizar a branch. Um PR `behind` pode ter auto-merge armado; o GitHub conclui o merge quando os requisitos forem atendidos. Sem depender de um segundo run.
2. **`clean status` não é mais erro fatal**: quando o GitHub responde que o PR já está `clean` (todos os required checks passaram e a branch está atualizada), o `enablePullRequestAutoMerge` falha. Antes isso caía no `throw error` e quebrava o job. Agora faz o merge (squash) direto — `clean` garante que os checks obrigatórios já passaram no head atual.

## Verificação

- YAML parseia e o script embutido passa em `node --check`.
- Só `.github/workflows/dependabot-automerge.yml` foi alterado; `auto-merge.yml` (PRs humanos) não é afetado.
- O próximo PR do dependabot exercita o caminho `behind`; PRs já verdes exercitam o caminho `clean status`.