### PR TITLE
fix(ci): exclude pip vendored packages from Trivy image scan

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -136,6 +136,10 @@ jobs:
           ignore-unfixed: true
           vuln-type: "os,library"
           scanners: "vuln"
+          # pip ships vendored copies (msgpack, pkg_resources/setuptools) listed in
+          # pip/_vendor/vendor.txt. They are not app dependencies and only move when
+          # pip itself re-vendors, so they would block every build forever.
+          skip-dirs: "**/site-packages/pip/_vendor"
           exit-code: "0"
           format: "json"
           output: "trivy-results-${{ matrix.target }}.json"
@@ -150,6 +154,10 @@ jobs:
           ignore-unfixed: true
           vuln-type: "os,library"
           scanners: "vuln"
+          # pip ships vendored copies (msgpack, pkg_resources/setuptools) listed in
+          # pip/_vendor/vendor.txt. They are not app dependencies and only move when
+          # pip itself re-vendors, so they would block every build forever.
+          skip-dirs: "**/site-packages/pip/_vendor"
           exit-code: "0"
           format: "json"
           output: "trivy-results-${{ matrix.target }}.json"
@@ -164,6 +172,10 @@ jobs:
           ignore-unfixed: true
           vuln-type: "os,library"
           scanners: "vuln"
+          # pip ships vendored copies (msgpack, pkg_resources/setuptools) listed in
+          # pip/_vendor/vendor.txt. They are not app dependencies and only move when
+          # pip itself re-vendors, so they would block every build forever.
+          skip-dirs: "**/site-packages/pip/_vendor"
           exit-code: "0"
           format: "sarif"
           output: "trivy-results-${{ matrix.target }}.sarif"
@@ -178,6 +190,10 @@ jobs:
           ignore-unfixed: true
           vuln-type: "os,library"
           scanners: "vuln"
+          # pip ships vendored copies (msgpack, pkg_resources/setuptools) listed in
+          # pip/_vendor/vendor.txt. They are not app dependencies and only move when
+          # pip itself re-vendors, so they would block every build forever.
+          skip-dirs: "**/site-packages/pip/_vendor"
           exit-code: "0"
           format: "sarif"
           output: "trivy-results-${{ matrix.target }}.sarif"


### PR DESCRIPTION
## Problema

`main` está vermelho desde o merge do #150 (run [30507688052](https://github.com/bernardopg/doctoralia-scrapper/actions/runs/30507688052)). Os jobs `Scan for Vulnerabilities (api)` e `(worker)` falham com:

```
Detected HIGH/CRITICAL vulnerabilities: 2
- [HIGH] msgpack 1.1.2 -> GHSA-6v7p-g79w-8964 (fixed: 1.2.1)
- [HIGH] setuptools 70.3.0 -> CVE-2025-47273 (fixed: 78.1.1)
```

Nenhum dos dois está instalado na imagem:

```
$ docker run --rm <api-image> pip list | grep -iE 'setuptools|msgpack'
setuptools  83.0.0
```

`poetry.lock` fixa `msgpack 1.2.1` e `requirements.txt` nem lista msgpack. As duas ocorrências vêm exclusivamente de:

```
$ docker run --rm <api-image> cat /usr/local/lib/python3.14/site-packages/pip/_vendor/vendor.txt
msgpack==1.1.2
setuptools==70.3.0
```

Ou seja: cópias que o **próprio pip** vendoriza para uso interno. O analisador `python-pkg` do Trivy lê esse manifesto e as reporta como pacotes da aplicação. Só somem quando o pip re-vendoriza upstream — até lá, todo build fica bloqueado.

## Correção

`skip-dirs: "**/site-packages/pip/_vendor"` nos 4 steps do `trivy-action`.

Escopo restrito ao diretório vendorizado, em vez de um `.trivyignore` com os IDs: CVEs reais de msgpack/setuptools continuam sendo reportados normalmente.

## Verificação

Build local do estágio `api` e scan com as mesmas flags do CI:

| | HIGH/CRITICAL |
|---|---|
| sem `skip-dirs` | 2 (msgpack, setuptools) |
| com `skip-dirs` | 0 |